### PR TITLE
Add link to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Render to a file:
 ## Templates
 
 You can find an example template to generate a GitHub profile README under
-`templates/github-profile.tpl`. Make sure to fill in (or remove) placeholders,
+[`templates/github-profile.tpl`](templates/github-profile.tpl). Make sure to fill in (or remove) placeholders,
 like the RSS-feed or social media URLs.
 
 Rendered it looks a little like my own profile page: https://github.com/muesli


### PR DESCRIPTION
Just a simple link added to `template/github-profile.tmp` in README.md. Makes it easier for users to go to it :)