### PR TITLE
Accommodate for a growing number of template functions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,7 @@ before:
 builds:
   -
     id: "markscribe"
+    main: ./cmd/main.go
     binary: markscribe
     ldflags: -s -w -X main.Version={{ .Version }} -X main.CommitSHA={{ .Commit }}
     goos:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"io/ioutil"
+
+	"github.com/muesli/markscribe/internal"
+)
+
+func main() {
+	flag.Parse()
+
+	if len(flag.Args()) == 0 {
+		fmt.Println("Usage: markscribe [template]")
+		os.Exit(1)
+	}
+
+	tplIn, err := ioutil.ReadFile(flag.Args()[0])
+	if err != nil {
+		fmt.Println("Can't read file:", err)
+		os.Exit(1)
+	}
+
+	err = internal.New(tplIn)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/internal/gists.go
+++ b/internal/gists.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"context"

--- a/internal/humanize.go
+++ b/internal/humanize.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"fmt"

--- a/internal/repos.go
+++ b/internal/repos.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"context"

--- a/internal/rss.go
+++ b/internal/rss.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"time"

--- a/internal/sponsors.go
+++ b/internal/sponsors.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"context"

--- a/internal/types.go
+++ b/internal/types.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"time"

--- a/internal/users.go
+++ b/internal/users.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"context"


### PR DESCRIPTION
Hello! 🎉

Thank you again for this awesome tool! Considering the growth this repository has had, I thought I could throw myself into trying to "organize it for growth" (feels very corporate thing to say). Anyway, what I did was move all Go files into `internal`, since, as of now there are no exported functions, and probably will not, right? Secondly, I added `cmd/main.go`.

I am but a novice Golang-programmer, so feedback would be magnificent. I'll improve as you see fit!

> **But, why not keep it as is?**

Mostly because if files are kept being added, the repository tree will be very long and people hate scrolling to the README 😅.

<table>
  <tr>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td>
<pre>
.
├── Dockerfile
├── LICENSE
├── README.md
├── gists.go
├── go.mod
├── go.sum
├── humanize.go
├── main.go
├── repos.go
├── rss.go
├── sponsors.go
├── templates
│   └── github-profile.tpl
├── types.go
└── users.go
</pre>
</td>
<td>
<pre>
.
├── Dockerfile
├── LICENSE
├── README.md
├── cmd
│   └── main.go
├── go.mod
├── go.sum
├── internal
│   ├── gists.go
│   ├── humanize.go
│   ├── main.go
│   ├── repos.go
│   ├── rss.go
│   ├── sponsors.go
│   ├── types.go
│   └── users.go
└── templates
    └── github-profile.tpl
</pre>
</td>
  </tr>
</table>