### PR TITLE
Add recent stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ CreatedAt: {{humanize .CreatedAt}}
 Repository name: {{.Repo.Name}}
 Repository description: {{.Repo.Description}}
 Repository URL: {{.Repo.URL}}
+{{end}}
 ```
 
 ### Repositories you recently starred

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ CreatedAt: {{humanize .CreatedAt}}
 Repository name: {{.Repo.Name}}
 Repository description: {{.Repo.Description}}
 Repository URL: {{.Repo.URL}}
+```
+
+### Repositories you recently starred
+
+```
+{{range recentStars 10}}
+Name: {{.Name}}
+Description: {{.Description}}
+URL: {{.URL}})
+Stars: {{.Stargazers}}
 {{end}}
 ```
 

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 		"recentRepos":         recentRepos,
 		"recentReleases":      recentReleases,
 		"followers":           recentFollowers,
+		"recentStars":         recentStars,
 		"gists":               gists,
 		"sponsors":            sponsors,
 		/* RSS */

--- a/repos.go
+++ b/repos.go
@@ -29,7 +29,7 @@ var recentContributionsQuery struct {
 
 var recentPullRequestsQuery struct {
 	User struct {
-		Login                   githubv4.String
+		Login        githubv4.String
 		PullRequests struct {
 			TotalCount githubv4.Int
 			Edges      []struct {

--- a/stars.go
+++ b/stars.go
@@ -15,8 +15,8 @@ var recentStarsQuery struct {
 	} `graphql:"user(login:$username)"`
 }
 
-func recentStars(count int) []Star {
-	var stars []Star
+func recentStars(count int) []Repo {
+	var starredRepos []Repo
 	variables := map[string]interface{}{
 		"username": githubv4.String(username),
 		"count":    githubv4.Int(count),
@@ -27,13 +27,10 @@ func recentStars(count int) []Star {
 	}
 
 	for _, v := range recentStarsQuery.User.Stars.Nodes {
-		s := Star{
-			Repo: RepoFromQL(v),
-		}
-		stars = append(stars, s)
+		starredRepos = append(starredRepos, RepoFromQL(v))
 	}
 
-	return stars
+	return starredRepos
 }
 
 /*

--- a/stars.go
+++ b/stars.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+
+	"github.com/shurcooL/githubv4"
+)
+
+var recentStarsQuery struct {
+	User struct {
+		Login githubv4.String
+		Stars struct {
+			Edges []struct {
+				Node QLStar
+			}
+		} `graphql:"starredRepositories(first: $count, orderBy: {field: STARRED_AT, direction: DESC})"`
+	} `graphql:"user(login:$username)"`
+}
+
+func recentStars(count int) []Star {
+	var stars []Star
+	variables := map[string]interface{}{
+		"username": githubv4.String(username),
+		"count":    githubv4.Int(count),
+	}
+	err := gitHubClient.Query(context.Background(), &recentStarsQuery, variables)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, v := range recentStarsQuery.User.Stars.Edges {
+		stars = append(stars, StarFromQL(v.Node))
+	}
+
+	return stars
+}
+
+/*
+{
+  viewer {
+    login
+    starredRepositories(first: 3, orderBy: {field: STARRED_AT, direction: DESC}) {
+      edges {
+        node {
+          nameWithOwner
+          url
+        }
+      }
+    }
+  }
+}
+*/

--- a/stars.go
+++ b/stars.go
@@ -10,9 +10,7 @@ var recentStarsQuery struct {
 	User struct {
 		Login githubv4.String
 		Stars struct {
-			Edges []struct {
-				Node QLStar
-			}
+			Nodes []QLRepository
 		} `graphql:"starredRepositories(first: $count, orderBy: {field: STARRED_AT, direction: DESC})"`
 	} `graphql:"user(login:$username)"`
 }
@@ -28,8 +26,11 @@ func recentStars(count int) []Star {
 		panic(err)
 	}
 
-	for _, v := range recentStarsQuery.User.Stars.Edges {
-		stars = append(stars, StarFromQL(v.Node))
+	for _, v := range recentStarsQuery.User.Stars.Nodes {
+		s := Star{
+			Repo: RepoFromQL(v),
+		}
+		stars = append(stars, s)
 	}
 
 	return stars
@@ -40,10 +41,12 @@ func recentStars(count int) []Star {
   viewer {
     login
     starredRepositories(first: 3, orderBy: {field: STARRED_AT, direction: DESC}) {
-      edges {
-        node {
-          nameWithOwner
-          url
+      nodes {
+        nameWithOwner
+        url
+        description
+        stargazers {
+          totalCount
         }
       }
     }

--- a/templates/github-profile.tpl
+++ b/templates/github-profile.tpl
@@ -27,7 +27,7 @@
 
 #### ⭐ Recent Stars
 {{range recentStars 10}}
-- [{{.Repo.Description}}]({{.Repo.URL}}) ({{humanize .CreatedAt}})
+- [{{.Repo.Name}}]({{.Repo.URL}}) - {{.Repo.Description}} ({{humanize .StarredAt}})
 {{- end}}
 
 #### ❤️ These awesome people sponsor me (thank you!)

--- a/templates/github-profile.tpl
+++ b/templates/github-profile.tpl
@@ -25,6 +25,11 @@
 - [{{.Description}}]({{.URL}}) ({{humanize .CreatedAt}})
 {{- end}}
 
+#### ⭐ Recent Stars
+{{range recentStars 10}}
+- [{{.Repo.Description}}]({{.Repo.URL}}) ({{humanize .CreatedAt}})
+{{- end}}
+
 #### ❤️ These awesome people sponsor me (thank you!)
 {{range sponsors 5}}
 - [{{.User.Login}}]({{.User.URL}}) ({{humanize .CreatedAt}})

--- a/types.go
+++ b/types.go
@@ -18,6 +18,11 @@ type Gist struct {
 	CreatedAt   time.Time
 }
 
+type Star struct {
+	StarredAt time.Time
+	Repo      Repo
+}
+
 type PullRequest struct {
 	Title     string
 	URL       string

--- a/types.go
+++ b/types.go
@@ -54,8 +54,9 @@ type User struct {
 }
 
 type Star struct {
-	Name string
-	URL  string
+	Name        string
+	URL         string
+	Description string
 }
 
 type QLGist struct {
@@ -104,6 +105,7 @@ type QLUser struct {
 type QLStar struct {
 	NameWithOwner githubv4.String
 	URL           githubv4.String
+	Description   githubv4.String
 }
 
 func GistFromQL(gist QLGist) Gist {
@@ -154,7 +156,8 @@ func UserFromQL(user QLUser) User {
 
 func StarFromQL(star QLStar) Star {
 	return Star{
-		Name: string(star.NameWithOwner),
-		URL:  string(star.URL),
+		Name:        string(star.NameWithOwner),
+		URL:         string(star.URL),
+		Description: string(star.Description),
 	}
 }

--- a/types.go
+++ b/types.go
@@ -54,9 +54,7 @@ type User struct {
 }
 
 type Star struct {
-	Name        string
-	URL         string
-	Description string
+	Repo Repo
 }
 
 type QLGist struct {
@@ -102,12 +100,6 @@ type QLUser struct {
 	URL       githubv4.String
 }
 
-type QLStar struct {
-	NameWithOwner githubv4.String
-	URL           githubv4.String
-	Description   githubv4.String
-}
-
 func GistFromQL(gist QLGist) Gist {
 	return Gist{
 		Name:        string(gist.Name),
@@ -151,13 +143,5 @@ func UserFromQL(user QLUser) User {
 		Name:      string(user.Name),
 		AvatarURL: string(user.AvatarURL),
 		URL:       string(user.URL),
-	}
-}
-
-func StarFromQL(star QLStar) Star {
-	return Star{
-		Name:        string(star.NameWithOwner),
-		URL:         string(star.URL),
-		Description: string(star.Description),
 	}
 }

--- a/types.go
+++ b/types.go
@@ -53,10 +53,6 @@ type User struct {
 	URL       string
 }
 
-type Star struct {
-	Repo Repo
-}
-
 type QLGist struct {
 	Name        githubv4.String
 	Description githubv4.String

--- a/types.go
+++ b/types.go
@@ -53,6 +53,11 @@ type User struct {
 	URL       string
 }
 
+type Star struct {
+	Name string
+	URL  string
+}
+
 type QLGist struct {
 	Name        githubv4.String
 	Description githubv4.String
@@ -94,6 +99,11 @@ type QLUser struct {
 	Name      githubv4.String
 	AvatarURL githubv4.String
 	URL       githubv4.String
+}
+
+type QLStar struct {
+	NameWithOwner githubv4.String
+	URL           githubv4.String
 }
 
 func GistFromQL(gist QLGist) Gist {
@@ -139,5 +149,12 @@ func UserFromQL(user QLUser) User {
 		Name:      string(user.Name),
 		AvatarURL: string(user.AvatarURL),
 		URL:       string(user.URL),
+	}
+}
+
+func StarFromQL(star QLStar) Star {
+	return Star{
+		Name: string(star.NameWithOwner),
+		URL:  string(star.URL),
 	}
 }


### PR DESCRIPTION
Closes #14 

This felt a bit repetitive since all the Star fields are already in the `Repo` / `QLRepository` structs, but I wanted to keep parity with the Github API and the fact that it's _technically_ still a separate query.

Just added

- name + owner
- HTTP repo URL
- repo description

for now. Tested it out locally on my own README template that's been using this tool for some time now 🙂