### PR TITLE
feat: add a new 'now' template helper

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/KyleBanks/goodreads"
 	"github.com/shurcooL/githubv4"
@@ -53,6 +54,7 @@ func main() {
 		/* Utils */
 		"humanize": humanized,
 		"reverse":  reverse,
+		"now":      time.Now,
 	}).Parse(string(tplIn))
 	if err != nil {
 		fmt.Println("Can't parse template:", err)


### PR DESCRIPTION
Usage examples:

    {{now}}                                             2009-11-10 23:00:00 &#43;0000 UTC m=&#43;0.000000001
    {{now.Unix}}                                        1257894000
    {{now.UnixNano}}                                    1257894000000000000
    {{now.Format `Mon Jan 2 15:04:05 -0700 MST 2006`}}  Tue Nov 10 23:00:00 &#43;0000 UTC 2009

https://play.golang.org/p/Pf5k_P1pP5M

---

My motivation is to add a "build date"