### PR TITLE
Fix documentation on starred repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ This function requires GitHub authentication with the following API scopes:
 
 ```
 {{range recentStars 10}}
-Name: {{.Name}}
-Description: {{.Description}}
-URL: {{.URL}})
-Stars: {{.Stargazers}}
+Name: {{.Repo.Name}}
+Description: {{.Repo.Description}}
+URL: {{.Repo.URL}})
+Stars: {{.Repo.Stargazers}}
 {{end}}
 ```
 
@@ -236,8 +236,8 @@ You also need to set your GoodReads user ID in your secrets as `GOODREADS_USER_I
 
 ## FAQ
 
-Q: That's awesome, but can you expose more APIs and data?  
+Q: That's awesome, but can you expose more APIs and data?
 A: Of course, just open a new issue and let me know what you'd like to do with markscribe!
 
-Q: That's awesome, but I don't have my own server to run this on. Can you help?  
+Q: That's awesome, but I don't have my own server to run this on. Can you help?
 A: Check out [readme-scribe](https://github.com/muesli/readme-scribe/), a GitHub Action that runs markscribe for you!

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ You also need to set your GoodReads user ID in your secrets as `GOODREADS_USER_I
 
 ## FAQ
 
-Q: That's awesome, but can you expose more APIs and data?
+Q: That's awesome, but can you expose more APIs and data?  
 A: Of course, just open a new issue and let me know what you'd like to do with markscribe!
 
-Q: That's awesome, but I don't have my own server to run this on. Can you help?
+Q: That's awesome, but I don't have my own server to run this on. Can you help?  
 A: Check out [readme-scribe](https://github.com/muesli/readme-scribe/), a GitHub Action that runs markscribe for you!


### PR DESCRIPTION
Fixes #35

The documentation in the readme for listing your starred repos is incorrect and failed when I tried to use it verbatim. I dug up the original PR that added the functionality and there is template syntax that is different from what is listed there. https://github.com/muesli/markscribe/pull/25/files#diff-48fcd2f0bdec681f14ab75bd86a8fe3da7f851523d98193380608632a13cbbd7R30

This fixes the docs to be correct. This syntax worked successfully for me in a workflow of mine.