### PR TITLE
add recentForks for github

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ Stars: {{.Stargazers}}
 This function requires GitHub authentication with the following API scopes:
 `repo:status`, `public_repo`, `read:user`.
 
+### Forks you recently created
+
+```
+{{range recentForks 10}}
+Name: {{.Name}}
+Description: {{.Description}}
+URL: {{.URL}})
+Stars: {{.Stargazers}}
+{{end}}
+```
+
+This function requires GitHub authentication with the following API scopes:
+`repo:status`, `public_repo`, `read:user`.
+
 ### Recent releases you contributed to
 
 ```

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 		"recentContributions": recentContributions,
 		"recentPullRequests":  recentPullRequests,
 		"recentRepos":         recentRepos,
+		"recentForks":         recentForks,
 		"recentReleases":      recentReleases,
 		"followers":           recentFollowers,
 		"recentStars":         recentStars,

--- a/templates/github-profile.tpl
+++ b/templates/github-profile.tpl
@@ -5,6 +5,11 @@
 - [{{.Repo.Name}}]({{.Repo.URL}}) - {{.Repo.Description}} ({{humanize .OccurredAt}})
 {{- end}}
 
+#### 🍴 My recent forks
+{{range recentForks 10}}
+- [{{.Repo.Name}}]({{.Repo.URL}}) - {{.Repo.Description}} ({{humanize .OccurredAt}})
+{{- end}}
+
 #### 🌱 My latest projects
 {{range recentRepos 10}}
 - [{{.Name}}]({{.URL}}) - {{.Description}}


### PR DESCRIPTION
I haven't actually tested this (outside messing with the github GraphQL explorer) but looking at the code it seems like you can additionally parameterize the query used by `recentRepos` to get forks.  I exposed it as an additional function `recentForks` to avoid any confusion caused around parameter naming.