### PR TITLE
Add variant of pullrequests on nonpersonal repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ Occurred: {{humanize .OccurredAt}}
 This function requires GitHub authentication with the following API scopes:
 `repo:status`, `public_repo`, `read:user`.
 
-### Your recent pull requests
+### Your recent pull requests/non-personal pull requests
 
+*pull requests*
 ```
 {{range recentPullRequests 10}}
 Title: {{.Title}}
@@ -87,6 +88,12 @@ Repository name: {{.Repo.Name}}
 Repository description: {{.Repo.Description}}
 Repository URL: {{.Repo.URL}}
 {{end}}
+```
+
+*non-personal pull requests*
+```
+{{range recentNonPersonalPullRequests 10}}
+... (rest is the same as pull requests)
 ```
 
 This function requires GitHub authentication with the following API scopes:

--- a/main.go
+++ b/main.go
@@ -41,15 +41,16 @@ func main() {
 
 	tpl, err := template.New("tpl").Funcs(template.FuncMap{
 		/* GitHub */
-		"recentContributions": recentContributions,
-		"recentPullRequests":  recentPullRequests,
-		"recentRepos":         recentRepos,
-		"recentForks":         recentForks,
-		"recentReleases":      recentReleases,
-		"followers":           recentFollowers,
-		"recentStars":         recentStars,
-		"gists":               gists,
-		"sponsors":            sponsors,
+		"recentContributions":           recentContributions,
+		"recentPullRequests":            recentPullRequests,
+		"recentNonPersonalPullRequests": recentNonPersonalPullRequests,
+		"recentRepos":                   recentRepos,
+		"recentForks":                   recentForks,
+		"recentReleases":                recentReleases,
+		"followers":                     recentFollowers,
+		"recentStars":                   recentStars,
+		"gists":                         gists,
+		"sponsors":                      sponsors,
 		/* RSS */
 		"rss": rssFeed,
 		/* GoodReads */


### PR DESCRIPTION
I have added functionality to allow users to display pull requests made in repositories that are not their own.

This was more of a personal need but I figured I'd see if this was something that might be useful to merge upstream. My use case is that I have a dependency updater bot (Renovate) run on a cron schedule that may automatically raise PRs in my name. Hence, the entries shown in my README consist mainly of these and not of those I wish to show off (e.g PRs done especially in third party repositories). These changes allow me to get around that limitation.

I'm open to suggestions, perhaps the terminology used here could be improved (or maybe it's just me :laughing: ).

(picture below was taken from my GitHub page using these changes)

![image](https://user-images.githubusercontent.com/31086993/170726383-a8dfdb41-2b5c-43ae-8059-6ed5584227a1.png)
