### PR TITLE
Add contains template func

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func main() {
 		"humanize": humanized,
 		"reverse":  reverse,
 		"now":      time.Now,
+		"contains": strings.Contains,
 		"toLower":  strings.ToLower,
 	}).Parse(string(tplIn))
 	if err != nil {


### PR DESCRIPTION
In my README template list "Recent releases", a list where I sometimes gets only vaguely relevant releases.

This relates to #40 -- but I'd rather fix this by filtering the entries with e.g.:

```
{{range recentReleases 10 }}
{{ or (contains .Name "bep") (contains .Name "hugo") }}
...
{{ end }}
{{ end }}
```


