### PR TITLE
chore: bump Go dep to 1.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [~1.11, ^1]
+        go-version: [~1.16, ^1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ packages.
 ### Build From Source
 
 Alternatively you can also build `markscribe` from source. Make sure you have a
-working Go environment (Go 1.11 or higher is required). See the
+working Go environment (Go 1.16 or higher is required). See the
 [install instructions](https://golang.org/doc/install.html).
 
 To install markscribe, simply run:


### PR DESCRIPTION
Required by `os.ReadFile`.