### PR TITLE
Fix build from source step

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ working Go environment (Go 1.16 or higher is required). See the
 
 To install markscribe, simply run:
 
-    go get github.com/muesli/markscribe
+    go install github.com/muesli/markscribe@latest
 
 ## Templates
 


### PR DESCRIPTION
As described here https://go.dev/doc/go-get-install-deprecation. Fresh `go get` only supposed to be used to update with go.mod

On current `golang` version execution of `go get <REPO>` trows following error:
```
~ ❯ go get github.com/muesli/markscribe
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```